### PR TITLE
Add blueprint for ROAF calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # HA-roaf-tommekalender
 Automasjon som henter ROAF tømmekalender datoer og lagrer det i home assistant kalender
+
+## Blueprint
+
+En ny Home Assistant blueprint `roaf_tommekalender` finnes under `blueprints/automation/roaf_tommekalender.yaml`.
+Blueprinten henter tømmekalender for en gitt adresse fra ROAF sitt API og legger de neste datoene inn i valgt kalender uten å opprette duplikater.
+Inputfeltene i UI krever app key, kommunenummer, gatenavn, gatekode, husnummer og kalenderen som skal brukes.
+

--- a/blueprints/automation/roaf_tommekalender.yaml
+++ b/blueprints/automation/roaf_tommekalender.yaml
@@ -1,0 +1,107 @@
+blueprint:
+  name: ROAF Hentekalender
+  description: >-
+    Hent hentedatoer fra ROAF sitt API og legg de til i Home Assistant kalenderen.
+  domain: automation
+  input:
+    appkey:
+      name: App Key
+      description: Nøkkel for ROAF API
+      selector:
+        text:
+    kommunenr:
+      name: Kommunenummer
+      selector:
+        text:
+    gatenavn:
+      name: Gatenavn
+      selector:
+        text:
+    gatekode:
+      name: Gatekode
+      selector:
+        text:
+    husnr:
+      name: Husnummer
+      selector:
+        text:
+    calendar:
+      name: Kalender
+      selector:
+        entity:
+          domain: calendar
+
+trigger:
+  - platform: template
+    value_template: >-
+      {{ now().isoweekday() == 1 }}
+
+variables:
+  api_url: >-
+    https://norkartrenovasjon.azurewebsites.net/proxyserver.ashx?server=https://komteksky.norkart.no/MinRenovasjon.Api/api/tommekalender/?kommunenr={{ kommunenr }}&gatenavn={{ gatenavn | urlencode }}&gatekode={{ gatekode }}&husnr={{ husnr }}
+
+mode: single
+
+sequence:
+  - alias: Hent tømmekalender fra ROAF
+    service: rest_command.roaf_hent
+    data:
+      url: "{{ api_url }}"
+      method: GET
+      headers:
+        Renovasjonappkey: "{{ appkey }}"
+        Kommunenr: "{{ kommunenr }}"
+    response_variable: roaf_response
+
+  - alias: Avbryt hvis feilet
+    if:
+      - condition: template
+        value_template: "{{ roaf_response['status'] != 200 }}"
+    then:
+      - service: persistent_notification.create
+        data:
+          title: 'ROAF kalender'
+          message: 'Kunne ikke hente data fra ROAF API'
+      - stop: API-feil
+
+  - variables:
+      upcoming: |
+        {% set events = state_attr(calendar, 'entries') %}
+        {% if events is none %}
+          []
+        {% else %}
+          {{ events }}
+        {% endif %}
+      existing_by_type: >-
+        {{ upcoming | groupby('summary') | map(attribute=1) | list }}
+      fraksjoner: |
+        {%- set data = roaf_response['content'] if roaf_response['content'] is string -%}
+        {%- set parsed = data | from_json -%}
+        {{ parsed }}
+
+  - repeat:
+      for_each: "{{ fraksjoner }}"
+      sequence:
+        - variables:
+            fraksjon: "{{ repeat.item.FraksjonId }}"
+            dates: "{{ repeat.item.Tommedatoer }}"
+            name: >-
+              {% if fraksjon == 1 %}Restavfall{% elif fraksjon == 2 %}Papir{% elif fraksjon == 17 %}Matavfall{% else %}Fraksjon {{ fraksjon }}{% endif %}
+            existing_dates: >-
+              {{ upcoming | selectattr('summary','==', name) | map(attribute='start') | list }}
+        - repeat:
+            for_each: "{{ dates }}"
+            sequence:
+              - if:
+                  - condition: template
+                    value_template: "{{ repeat.item[:10] not in existing_dates }}"
+                then:
+                  - service: calendar.create_event
+                    target:
+                      entity_id: !input calendar
+                    data:
+                      summary: "{{ name }}"
+                      start_date: "{{ repeat.item[:10] }}"
+                      end_date: >-
+                        {{ (as_datetime(repeat.item[:10]) + timedelta(days=1)).strftime('%Y-%m-%d') }}
+


### PR DESCRIPTION
## Summary
- add automation blueprint for fetching ROAF trash collection dates
- update README with blueprint location

## Testing
- `python - <<'PY'
import yaml,sys
class NoTag(yaml.SafeLoader):
    pass
NoTag.add_constructor(None, lambda loader,node: None)
try:
    yaml.load(open('blueprints/automation/roaf_tommekalender.yaml'), Loader=NoTag)
    print('ok')
except Exception as e:
    print('fail', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_686397f507988331be13a2bac473a9ae