### PR TITLE
Update blueprint README and add rest_command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,22 @@ En ny Home Assistant blueprint `roaf_tommekalender` finnes under `blueprints/aut
 Blueprinten henter tømmekalender for en gitt adresse fra ROAF sitt API og legger de neste datoene inn i valgt kalender uten å opprette duplikater.
 Inputfeltene i UI krever app key, kommunenummer, gatenavn, gatekode, husnummer og kalenderen som skal brukes.
 
+### rest_command `roaf_hent`
+
+Blueprinten kaller et Home Assistant `rest_command` ved navn `roaf_hent` for å hente data fra ROAF API.
+Legg følgende i `configuration.yaml` (eller i en inkludert fil):
+
+```yaml
+rest_command:
+  roaf_hent:
+    url: "{{ url }}"
+    method: "{{ method }}"
+    headers:
+      Renovasjonappkey: "{{ headers.Renovasjonappkey }}"
+      Kommunenr: "{{ headers.Kommunenr }}"
+```
+
+Automasjonen fyller inn variablene som brukes av `rest_command` når den kalles.
+En eksempelfil `rest_command.yaml` følger med i repoet dersom du ønsker å
+inkludere den direkte.
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Legg følgende i `configuration.yaml` (eller i en inkludert fil):
 rest_command:
   roaf_hent:
     url: "{{ url }}"
-    method: "{{ method }}"
+    method: GET
     headers:
       Renovasjonappkey: "{{ headers.Renovasjonappkey }}"
       Kommunenr: "{{ headers.Kommunenr }}"

--- a/blueprints/automation/roaf_tommekalender.yaml
+++ b/blueprints/automation/roaf_tommekalender.yaml
@@ -2,6 +2,7 @@ blueprint:
   name: ROAF Hentekalender
   description: >-
     Hent hentedatoer fra ROAF sitt API og legg de til i Home Assistant kalenderen.
+    Krever at `rest_command.roaf_hent` er konfigurert. Se README for detaljer.
   domain: automation
   input:
     appkey:

--- a/blueprints/automation/roaf_tommekalender.yaml
+++ b/blueprints/automation/roaf_tommekalender.yaml
@@ -2,7 +2,6 @@ blueprint:
   name: ROAF Hentekalender
   description: >-
     Hent hentedatoer fra ROAF sitt API og legg de til i Home Assistant kalenderen.
-    Krever at `rest_command.roaf_hent` er konfigurert. Se README for detaljer.
   domain: automation
   input:
     appkey:
@@ -38,12 +37,22 @@ trigger:
       {{ now().isoweekday() == 1 }}
 
 variables:
-  api_url: >-
-    https://norkartrenovasjon.azurewebsites.net/proxyserver.ashx?server=https://komteksky.norkart.no/MinRenovasjon.Api/api/tommekalender/?kommunenr={{ kommunenr }}&gatenavn={{ gatenavn | urlencode }}&gatekode={{ gatekode }}&husnr={{ husnr }}
+  # Make blueprint input available as a script level variable
+  kommunenr: !input kommunenr
+  gatenavn: !input gatenavn
+  gatekode: !input gatekode
+  husnr: !input husnr
+  appkey: !input appkey
+  calendar: !input calendar
 
 mode: single
 
-sequence:
+actions:
+  - alias: Bygge api url fra input
+    variables:
+      #build api url from input
+      api_url: "https://norkartrenovasjon.azurewebsites.net/proxyserver.ashx?server=https://komteksky.norkart.no/MinRenovasjon.Api/api/tommekalender/?kommunenr={{ kommunenr }}&gatenavn={{ gatenavn | urlencode }}&gatekode={{ gatekode }}&husnr={{ husnr }}"
+
   - alias: Hent tømmekalender fra ROAF
     service: rest_command.roaf_hent
     data:
@@ -61,8 +70,8 @@ sequence:
     then:
       - service: persistent_notification.create
         data:
-          title: 'ROAF kalender'
-          message: 'Kunne ikke hente data fra ROAF API'
+          title: "ROAF kalender"
+          message: "Kunne ikke hente data fra ROAF API"
       - stop: API-feil
 
   - variables:
@@ -105,4 +114,3 @@ sequence:
                       start_date: "{{ repeat.item[:10] }}"
                       end_date: >-
                         {{ (as_datetime(repeat.item[:10]) + timedelta(days=1)).strftime('%Y-%m-%d') }}
-

--- a/rest_command.yaml
+++ b/rest_command.yaml
@@ -1,0 +1,8 @@
+rest_command:
+  roaf_hent:
+    url: "{{ url }}"
+    method: "{{ method }}"
+    headers:
+      Renovasjonappkey: "{{ headers.Renovasjonappkey }}"
+      Kommunenr: "{{ headers.Kommunenr }}"
+

--- a/rest_command.yaml
+++ b/rest_command.yaml
@@ -1,7 +1,7 @@
 rest_command:
   roaf_hent:
     url: "{{ url }}"
-    method: "{{ method }}"
+    method: GET
     headers:
       Renovasjonappkey: "{{ headers.Renovasjonappkey }}"
       Kommunenr: "{{ headers.Kommunenr }}"


### PR DESCRIPTION
## Summary
- add rest_command definition
- update blueprint description mentioning rest_command
- describe how to set up `roaf_hent` in README

## Testing
- `yamllint -d relaxed blueprints/automation/roaf_tommekalender.yaml rest_command.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6863b2fd86e8833189a00092bf3cf3f4