### PR TITLE
Fix #3 Get calendar events via an action and fix templates

### DIFF
--- a/blueprints/automation/roaf_tommekalender.yaml
+++ b/blueprints/automation/roaf_tommekalender.yaml
@@ -74,16 +74,18 @@ actions:
           message: "Kunne ikke hente data fra ROAF API"
       - stop: API-feil
 
+  - action: calendar.get_events
+    metadata: {}
+    data:
+      duration:
+        days: 60
+    target:
+      entity_id: calendar.mullkalender
+    response_variable: upcoming
+
   - variables:
-      upcoming: |
-        {% set events = state_attr(calendar, 'entries') %}
-        {% if events is none %}
-          []
-        {% else %}
-          {{ events }}
-        {% endif %}
       existing_by_type: >-
-        {{ upcoming | groupby('summary') | map(attribute=1) | list }}
+        {{ upcoming['calendar.mullkalender']['events'] }}
       fraksjoner: |
         {%- set data = roaf_response['content'] if roaf_response['content'] is string -%}
         {%- set parsed = data | from_json -%}
@@ -98,7 +100,10 @@ actions:
             name: >-
               {% if fraksjon == 1 %}Restavfall{% elif fraksjon == 2 %}Papir{% elif fraksjon == 17 %}Matavfall{% else %}Fraksjon {{ fraksjon }}{% endif %}
             existing_dates: >-
-              {{ upcoming | selectattr('summary','==', name) | map(attribute='start') | list }}
+              {{ existing_by_type | selectattr('summary', '==', name)
+                | map(attribute='start')
+                | list
+              }}
         - repeat:
             for_each: "{{ dates }}"
             sequence:

--- a/blueprints/automation/roaf_tommekalender.yaml
+++ b/blueprints/automation/roaf_tommekalender.yaml
@@ -81,11 +81,11 @@ actions:
         days: 60
     target:
       entity_id: calendar.mullkalender
-    response_variable: upcoming
+    response_variable: upcoming_events
 
   - variables:
-      existing_by_type: >-
-        {{ upcoming['calendar.mullkalender']['events'] }}
+      upcoming_events: >-
+        {{ upcoming_events['calendar.mullkalender']['events'] }}
       fraksjoner: |
         {%- set data = roaf_response['content'] if roaf_response['content'] is string -%}
         {%- set parsed = data | from_json -%}
@@ -100,7 +100,7 @@ actions:
             name: >-
               {% if fraksjon == 1 %}Restavfall{% elif fraksjon == 2 %}Papir{% elif fraksjon == 17 %}Matavfall{% else %}Fraksjon {{ fraksjon }}{% endif %}
             existing_dates: >-
-              {{ existing_by_type | selectattr('summary', '==', name)
+              {{ upcoming_events | selectattr('summary', '==', name)
                 | map(attribute='start')
                 | list
               }}


### PR DESCRIPTION
Fix #3
The duplicate events were created because the automation did not retrieve existing events from the calendar correctly. This along with the adjustments to templates for comparing with existing dates has fixed the issue